### PR TITLE
add dependency on cohttp

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -14,7 +14,7 @@ OCamlVersion:           >= 4.01
 Library "bs-aws"
   Path:                 lib
   XMETARequires:        lwt,yojson,xmlm,ezxmlm,base64,cohttp.lwt
-  BuildDepends:         lwt.ppx,yojson,xmlm,ezxmlm,base64,cohttp.lwt,threads,cryptokit
+  BuildDepends:         lwt.ppx,yojson,xmlm,ezxmlm,base64,cohttp,cohttp.lwt,threads,cryptokit
   InternalModules:      Aws_base, Aws_request, Aws_signature
   Modules:              Aws_common, Aws_elastic_transcoder, Aws_lambda,
                         Aws_s3, Aws_sns, Aws_sqs, Aws_ses, Aws_rds,


### PR DESCRIPTION
missing dependency to cohttp producing 

```
ocsigenserver: ocsigen:main: Fatal - While loading /Users/remy/.opam/system/lib/bs-aws/bs-aws.cma: error while linking /Users/remy/.opam/system/lib/bs-aws/bs-aws.cma.
ocsigenserver: ocsigen:main: Reference to undefined global `Cohttp__Code'
```